### PR TITLE
Fix site archive password retrieval

### DIFF
--- a/press/agent.py
+++ b/press/agent.py
@@ -455,11 +455,8 @@ class Agent:
 
 	def archive_site(self, site, site_name=None, force=False):
 		site_name = site_name or site.name
-		database_server = frappe.db.get_value("Bench", site.bench, "database_server")
 		data = {
-			"mariadb_root_password": get_decrypted_password(
-				"Database Server", database_server, "mariadb_root_password"
-			),
+			"mariadb_root_password": get_mariadb_root_password(site),
 			"force": force,
 		}
 


### PR DESCRIPTION
## Summary
- fetch the MariaDB root password using `get_mariadb_root_password` in `Agent.archive_site`

## Testing
- `ruff check press/agent.py --quiet`
- `pytest` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_6871f3b4e1ec83319771f4ec22e41019