### PR TITLE
Fix setup-pre-commit shebang and trailing prompt

### DIFF
--- a/setup-pre-commit.sh
+++ b/setup-pre-commit.sh
@@ -1,4 +1,4 @@
-# !/usr/bin/env bash
+#!/usr/bin/env bash
 
 echo "Installing python dev dependencies"
 pip install -r dev-requirements.txt


### PR DESCRIPTION
## Summary
- update the shebang in `setup-pre-commit.sh`
- remove stray prompt text and ensure file ends with newline

## Testing
- `bash -n setup-pre-commit.sh`
- `bash setup-pre-commit.sh` *(fails: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_6874e97ea7d8833180ac3b48f4e02f38