### PR TITLE
Run Prometheus configuration as root

### DIFF
--- a/press/playbooks/roles/reconfigure_prometheus/tasks/main.yml
+++ b/press/playbooks/roles/reconfigure_prometheus/tasks/main.yml
@@ -36,11 +36,12 @@
 
 - name: Configure Prometheus
   become: yes
-  become_user: frappe
   template:
     src: ../../prometheus/templates/prometheus.yml
     dest: /home/frappe/prometheus/prometheus.yml
     force: true
+    owner: frappe
+    group: frappe
     mode: 0600
     validate: "/home/frappe/prometheus/promtool check config %s"
 


### PR DESCRIPTION
## Summary
- run Configure Prometheus task as root and keep generated config owned by `frappe`

## Testing
- `ansible-playbook -i localhost, -c local press/playbooks/reconfigure_monitoring.yml -e 'registries_json="[]"' -e 'clusters_json="[]"' -e 'log_servers_json="[]"'` *(fails: ModuleNotFoundError: ansible.module_utils.six.moves)*
- `pre-commit run --files press/playbooks/roles/reconfigure_prometheus/tasks/main.yml` *(fails: pre-commit not installed; network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68c7bfc16ee08331992288c99ee60d52