### PR TITLE
Handle proxy server setup failures

### DIFF
--- a/press/press/doctype/proxy_server/proxy_server.json
+++ b/press/press/doctype/proxy_server/proxy_server.json
@@ -6,6 +6,7 @@
  "engine": "InnoDB",
  "field_order": [
   "status",
+  "last_setup_traceback",
   "hostname",
   "hostname_abbreviation",
   "domain",
@@ -97,6 +98,12 @@
    "options": "Pending\nInstalling\nActive\nBroken\nArchived",
    "read_only": 1,
    "reqd": 1
+  },
+  {
+   "fieldname": "last_setup_traceback",
+   "fieldtype": "Long Text",
+   "label": "Last Setup Traceback",
+   "read_only": 1
   },
   {
    "default": "0",
@@ -433,7 +440,7 @@
   }
  ],
  "links": [],
- "modified": "2025-06-13 12:52:19.785213",
+ "modified": "2025-10-10 12:41:08.477871",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Proxy Server",

--- a/press/press/doctype/proxy_server/proxy_server.py
+++ b/press/press/doctype/proxy_server/proxy_server.py
@@ -49,6 +49,7 @@ class ProxyServer(BaseServer):
 		is_server_setup: DF.Check
 		is_ssh_proxy_setup: DF.Check
 		is_wireguard_setup: DF.Check
+		last_setup_traceback: DF.LongText | None
 		primary: DF.Link | None
 		private_ip: DF.Data | None
 		private_ip_interface_id: DF.Data | None
@@ -143,37 +144,58 @@ class ProxyServer(BaseServer):
 			kibana_password = None
 
 		try:
-			ansible = Ansible(
-				playbook="self_hosted_proxy.yml" if getattr(self, "is_self_hosted", False) else "proxy.yml",
-				server=self,
-				user=self.ssh_user or "root",
-				port=self.ssh_port or 22,
-				variables={
-					"server": self.name,
-					"workers": 1,
-					"domain": self.domain,
-					"agent_password": agent_password,
-					"agent_repository_url": agent_repository_url,
-					"monitoring_password": monitoring_password,
-					"log_server": log_server,
-					"kibana_password": kibana_password,
-					"certificate_private_key": certificate.private_key,
-					"certificate_full_chain": certificate.full_chain,
-					"certificate_intermediate_chain": certificate.intermediate_chain,
-					"press_url": frappe.utils.get_url(),
-				},
-			)
-			play = ansible.run()
-			self.reload()
-			if play.status == "Success":
-				self.status = "Active"
-				self.is_server_setup = True
-			else:
-				self.status = "Broken"
-		except Exception:
-			self.status = "Broken"
-			log_error("Proxy Server Setup Exception", server=self.as_dict())
-		self.save()
+		        ansible = Ansible(
+		                playbook="self_hosted_proxy.yml" if getattr(self, "is_self_hosted", False) else "proxy.yml",
+		                server=self,
+		                user=self.ssh_user or "root",
+		                port=self.ssh_port or 22,
+		                variables={
+		                        "server": self.name,
+		                        "workers": 1,
+		                        "domain": self.domain,
+		                        "agent_password": agent_password,
+		                        "agent_repository_url": agent_repository_url,
+		                        "monitoring_password": monitoring_password,
+		                        "log_server": log_server,
+		                        "kibana_password": kibana_password,
+		                        "certificate_private_key": certificate.private_key,
+		                        "certificate_full_chain": certificate.full_chain,
+		                        "certificate_intermediate_chain": certificate.intermediate_chain,
+		                        "press_url": frappe.utils.get_url(),
+		                },
+		        )
+		        play = ansible.run()
+		        self.reload()
+		        if play.status == "Success":
+		                self.status = "Active"
+		                self.is_server_setup = True
+		                self.last_setup_traceback = None
+		        else:
+		                self.status = "Broken"
+		except Exception as exc:
+		        self.status = "Broken"
+		        error_message = (
+		                frappe.get_traceback(with_context=True)
+		                or str(exc)
+		                or "Proxy Server setup failed"
+		        )
+		        self.last_setup_traceback = error_message
+		        frappe.db.set_value(
+		                self.doctype,
+		                self.name,
+		                {"status": "Broken", "last_setup_traceback": error_message},
+		        )
+		        log_error(
+		                "Proxy Server Setup Exception",
+		                server=self.as_dict(),
+		                error_message=str(exc),
+		                traceback=error_message,
+		        )
+		        raise frappe.ValidationError(
+		                f"Failed to setup Proxy Server {self.name}: {exc}"
+		        ) from exc
+		else:
+		        self.save()
 
 	def _install_exporters(self):
 		monitoring_password = frappe.get_doc("Cluster", self.cluster).get_password("monitoring_password")

--- a/press/press/doctype/proxy_server/test_proxy_server.py
+++ b/press/press/doctype/proxy_server/test_proxy_server.py
@@ -13,6 +13,7 @@ from press.press.doctype.agent_job.test_agent_job import fake_agent_job
 from press.press.doctype.press_settings.test_press_settings import (
 	create_test_press_settings,
 )
+from press.press.doctype.proxy_server import proxy_server
 from press.press.doctype.proxy_server.proxy_server import ProxyServer
 from press.press.doctype.root_domain.root_domain import RootDomain
 from press.press.doctype.server.server import BaseServer
@@ -93,3 +94,21 @@ class TestProxyServer(FrappeTestCase):
 		self.assertFalse(proxy1.is_primary)
 		self.assertEqual(proxy2.status, "Active")
 		self.assertEqual(proxy1.status, "Active")
+
+	def test_setup_server_logs_and_raises(self):
+		proxy = create_test_proxy_server()
+		ansible = proxy_server.Ansible
+		ansible.return_value.run.side_effect = RuntimeError("ansible boom")
+
+		with patch("press.press.doctype.proxy_server.proxy_server.log_error") as log_error:
+			with self.assertRaises(frappe.ValidationError) as exc_info:
+				proxy._setup_server()
+
+		self.assertIn("ansible boom", str(exc_info.exception))
+		log_error.assert_called_once()
+		self.assertIn("ansible boom", log_error.call_args.kwargs["traceback"])
+
+		proxy.reload()
+		self.assertEqual(proxy.status, "Broken")
+		self.assertTrue(proxy.last_setup_traceback)
+		self.assertIn("ansible boom", proxy.last_setup_traceback)


### PR DESCRIPTION
## Summary
- add a read-only field on Proxy Server to capture the most recent setup traceback
- raise a ValidationError from _setup_server after persisting traceback details so job logs show the failure
- extend proxy server tests to assert that ansible failures are logged and surfaced

## Testing
- pytest press/press/doctype/proxy_server/test_proxy_server.py *(fails: ModuleNotFoundError: No module named 'frappe')*


------
https://chatgpt.com/codex/tasks/task_e_68e8fd65467483319ceb2dfdbd468923